### PR TITLE
DFT-73: Update Java/Spring to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.apds.model</groupId>
     <artifactId>model</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 
@@ -56,6 +56,7 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>6.0.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,20 +7,20 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.7.RELEASE</version>
+        <version>3.2.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
-    <groupId>com.platform.apds</groupId>
+    <groupId>org.apds.model</groupId>
     <artifactId>model</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -33,21 +33,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.10</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.9.10</version>
         </dependency>
-
 
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -57,17 +53,22 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
 
     </dependencies>
 
@@ -78,27 +79,8 @@
         </snapshotRepository>
     </distributionManagement>
 
-
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <!-- <id>plexx-nexus</id> -->
-                    <url>https://nexus.plexx.digital/repository/maven-snapshots/</url>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/main/java/org/apds/model/common/Reference.java
+++ b/src/main/java/org/apds/model/common/Reference.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Data
 public class Reference {

--- a/src/main/java/org/apds/model/common/VehicleAncilliaryIdentification.java
+++ b/src/main/java/org/apds/model/common/VehicleAncilliaryIdentification.java
@@ -3,7 +3,7 @@ package org.apds.model.common;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public class VehicleAncilliaryIdentification {
 

--- a/src/main/java/org/apds/model/common/VersionedReference.java
+++ b/src/main/java/org/apds/model/common/VersionedReference.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 
 public class VersionedReference implements Serializable {

--- a/src/main/java/org/apds/model/protocol/ServiceResponse.java
+++ b/src/main/java/org/apds/model/protocol/ServiceResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apds.model.common.Mapper;
 import org.springframework.http.HttpStatus;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class ServiceResponse {
 

--- a/src/main/java/org/apds/model/rights/CredentialAssigned.java
+++ b/src/main/java/org/apds/model/rights/CredentialAssigned.java
@@ -6,7 +6,7 @@ import org.apds.model.enums.CredentialType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/org/apds/model/rights/PlannedUse.java
+++ b/src/main/java/org/apds/model/rights/PlannedUse.java
@@ -9,7 +9,7 @@ import org.apds.model.enums.IssueMethod;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 

--- a/src/test/java/org/apds/model/mapping/DateParsingTests.java
+++ b/src/test/java/org/apds/model/mapping/DateParsingTests.java
@@ -2,7 +2,7 @@ package org.apds.model.mapping;
 
 import org.apds.model.common.Mapper;
 import org.apds.model.events.SessionCreated;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.springframework.test.util.AssertionErrors.assertNotNull;
 

--- a/src/test/java/org/apds/model/place/contacts/OrganisationTests.java
+++ b/src/test/java/org/apds/model/place/contacts/OrganisationTests.java
@@ -1,6 +1,6 @@
 package org.apds.model.place.contacts;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.springframework.test.util.AssertionErrors.assertNotNull;
 

--- a/src/test/java/org/apds/model/sessions/VehicleTests.java
+++ b/src/test/java/org/apds/model/sessions/VehicleTests.java
@@ -1,8 +1,8 @@
 package org.apds.model.sessions;
 
 import org.apds.model.common.VehicleAncilliaryIdentification;
-import org.junit.Test;
 
+import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 import static org.springframework.test.util.AssertionErrors.assertEquals;


### PR DESCRIPTION
This updates the common model to use the latest versions of Java and Spring:
- Update Java to version 21
- Update Spring Boot to version 3 (Spring 6)
- Update other packages where required to fix compatibility issues
- JUnit is updated to version 5 by this change, so unit tests required some updates to package names

The common model version has been updated from 2.0 to 3.0 due to these changes, so that any npp projects which have not yet been updated continue to use the older version. The package name has also been changed to org.apds.model in line with other projects.